### PR TITLE
Feature/undefined actions and alerts

### DIFF
--- a/src/impl/mold_lib-impl-variables.adb
+++ b/src/impl/mold_lib-impl-variables.adb
@@ -51,10 +51,9 @@ package body Mold_Lib.Impl.Variables is
       elsif Key = "mold-abort-on-error" then
          Set_Boolean (Args.Settings.Abort_On_Error'Access);
 
-      elsif Key = "mold-undefined-variable-action" then
+      elsif Key = "mold-undefined-action" then
          begin
-            Args.Settings.Undefined_Variable_Action :=
-              Undefined_Variable_Actions'Value (Value);
+            Args.Settings.Undefined_Action := Undefined_Actions'Value (Value);
          exception
             when E : Constraint_Error =>
                Log_Exception
@@ -62,18 +61,12 @@ package body Mold_Lib.Impl.Variables is
                Success := False;
          end;
 
-      elsif Key = "mold-undefined-variable-alert"
-        or else Key = "mold-undefined-filter-alert"
-      then
+      elsif Key = "mold-undefined-alert" then
          declare
             Undefined_Alert : Undefined_Alerts;
          begin
-            Undefined_Alert := Undefined_Alerts'Value (Value);
-            if Key = "mold-undefined-variable-alert" then
-               Args.Settings.Undefined_Variable_Alert := Undefined_Alert;
-            else
-               Args.Settings.Undefined_Filter_Alert := Undefined_Alert;
-            end if;
+            Undefined_Alert               := Undefined_Alerts'Value (Value);
+            Args.Settings.Undefined_Alert := Undefined_Alert;
          exception
             when E : Constraint_Error =>
                Log_Exception

--- a/src/mold_lib.ads
+++ b/src/mold_lib.ads
@@ -21,20 +21,19 @@ package Mold_Lib is
    --  Error level to assume when undefined things are encountered, e.g.
    --  undefined variable or undefined custom text filter.
 
-   type Undefined_Variable_Actions is (Ignore, Empty);
-   --  Action to perform when an undefined variable is found. 'Ignore' means
-   --  that there is no substitution at all, and the same variable
-   --  substitution will appear (e.g. '{{My_Var}}'). 'Empty' will completely
-   --  remove the variable (empty string).
+   type Undefined_Actions is (Ignore, Empty);
+   --  Action to perform when an undefined variable or text filter is found.
+   --  'Ignore' means that there is no substitution at all, and the same
+   --  variable substitution will appear (e.g. '{{My_Var}}'). 'Empty' will
+   --  completely remove the variable (empty string).
 
    type Settings_Type is record
       Replacement_In_File_Names   : aliased Boolean;
       Delete_Source_Files         : aliased Boolean;
       Overwrite_Destination_Files : aliased Boolean;
       Enable_Defined_Settings     : aliased Boolean;
-      Undefined_Variable_Action   : aliased Undefined_Variable_Actions;
-      Undefined_Variable_Alert    : aliased Undefined_Alerts;
-      Undefined_Filter_Alert      : aliased Undefined_Alerts;
+      Undefined_Action            : aliased Undefined_Actions;
+      Undefined_Alert             : aliased Undefined_Alerts;
       Abort_On_Error              : aliased Boolean;
    end record;
    type Settings_Access is access all Settings_Type;
@@ -46,9 +45,8 @@ package Mold_Lib is
       Delete_Source_Files         => True,
       Overwrite_Destination_Files => False,
       Enable_Defined_Settings     => True,
-      Undefined_Variable_Action   => Ignore,
-      Undefined_Variable_Alert    => Error,
-      Undefined_Filter_Alert      => Warning,
+      Undefined_Action            => Ignore,
+      Undefined_Alert             => Error,
       Abort_On_Error              => True
    );
 
@@ -63,8 +61,6 @@ package Mold_Lib is
       Variables_Replaced,
       Variables_Ignored,
       Variables_Emptied,
-      Filters_Found,
-      Filters_Applied,
       Replacement_Warnings,
       Replacement_Errors
    );

--- a/src/text_filters/impl/text_filters.adb
+++ b/src/text_filters/impl/text_filters.adb
@@ -52,11 +52,9 @@ package body Text_Filters is
 
    --!pp off
    function Apply (
-      Filters        :     String;
-      Value          :     String;
-      Output         :     IO.File_Type;
-      Summary        : out Results_Type;
-      Abort_On_Error :     Boolean := True
+      Filters           : String;
+      Value             : String;
+      Output            : IO.File_Type
    )  return UString
    --!pp on
 
@@ -64,34 +62,23 @@ package body Text_Filters is
       pragma Unreferenced
         (Output);  --  !TODO To be used with paragraph filters
 
-      Filter_Parsed : Text_Filter_Parsed;
-
-      Result : UString := To_Unbounded_String (Value);
-      Filter : UString := To_Unbounded_String (Filters);
-      Tail   : UString;
+      Parsing : Text_Filter_Parsed;
+      Result  : UString := To_Unbounded_String (Value);
+      Filter  : UString := To_Unbounded_String (Filters);
+      Tail    : UString;
    begin
-      Summary := (others => 0);
-
-      Log.Debug ("Abort_On_Error : " & Abort_On_Error'Image);
-
       Apply_All_Text_Filters_Loop :
       loop
-         Filter_Parsed := Parse (Filter, Tail);
-         Summary.Found := @ + 1;
+         Parsing := Parse (Filter, Tail);
 
-         if Filter_Parsed.Kind = filter_error then
-            Log.Error
-              ("Text Filter Error: " & To_String (Filter_Parsed.Error));
-            Summary.Errors := @ + 1;
-            if Abort_On_Error then
-               exit Apply_All_Text_Filters_Loop;
-            end if;
+         if Parsing.Kind = filter_error then
+            Result := Null_Unbounded_String;
+            exit Apply_All_Text_Filters_Loop;
          else
-            Result          := Apply (Filter_Parsed, Result);
-            Summary.Applied := @ + 1;
+            Result := Apply (Parsing, Result);
          end if;
 
-         Log.Debug ("Filter_Parsed : " & Filter_Parsed'Image);
+         Log.Debug ("Filter_Parsed : " & Parsing'Image);
          Log.Debug ("Tail          : '" & Tail'Image & "'");
          Log.Debug ("Result        : '" & To_String (Result) & "'");
 

--- a/src/text_filters/text_filters.ads
+++ b/src/text_filters/text_filters.ads
@@ -15,28 +15,14 @@ package Text_Filters is
 
    package IO renames Ada.Text_IO;
 
-   type Results_Type is record
-      Found   : Natural := 0;
-      Applied : Natural := 0;
-      Errors  : Natural := 0;
-   end record;
-   --  This is the summary of results during the application of a text filter
-   --  (or a chain of text filters):
-   --
-   --     Found   : total number of filters found in a sequence
-   --     Applied : number of filters applied
-   --     Errors  : number of errors found
-
    procedure Set_Custom_Text_Filters (Text_Filters : Filters_Access);
    --  Set custom text filters to be applied during the Apply process.
 
    --!pp off
    function Apply (
-      Filters        :     String;
-      Value          :     String;
-      Output         :     IO.File_Type;
-      Summary        : out Results_Type;
-      Abort_On_Error :     Boolean := True
+      Filters          : String;
+      Value            : String;
+      Output           : IO.File_Type
    )  return UString;  --  Ada.Strings.Unbounded.Unbounded_String
    --!pp on
    --
@@ -44,10 +30,11 @@ package Text_Filters is
    --  paragraph-formatting filters. Results contain the summary of the
    --  operation.
    --
-   --  When Abort_On_Error is True, if the process finds an undefined text
-   --  filter or erroneously specified, then the process stops immediately and
-   --  reports an error. Otherwise, the process continues with the remaining
-   --  filters and these erroneous filters are simply skipped but reported as
-   --  errors.
+   --  In the presence of undefined text filters (or erroneously specified),
+   --  the function returns Null_Unbounded_String.
+
+   --  If there are several filters in sequence, e.g. '/Ta/s/0', the filter
+   --  application is "unique". That is, if any of the multiple filters is
+   --  undefined, then no filter is applied.
 
 end Text_Filters;

--- a/tests/src/directory_tests.adb
+++ b/tests/src/directory_tests.adb
@@ -55,9 +55,8 @@ package body Directory_Tests is
       Settings.Delete_Source_Files         := True;  --  changed in def file
       Settings.Overwrite_Destination_Files := True;
       Settings.Enable_Defined_Settings     := True;
-      Settings.Undefined_Variable_Action   := Empty; --  changed in def file
-      Settings.Undefined_Variable_Alert    := None;  --  changed in def file
-      Settings.Undefined_Filter_Alert      := None;  --  changed in def file
+      Settings.Undefined_Action            := Empty; --  changed in def file
+      Settings.Undefined_Alert             := None;  --  changed in def file
       Settings.Abort_On_Error              := True;  --  changed in def file
       --!pp off
       Errors := Apply (
@@ -85,7 +84,7 @@ package body Directory_Tests is
          Files_Processed      =>    7,
          Files_Renamed        =>    2,
          Files_Overwritten    =>    0,
-         Variables_Defined    =>    6 + 26 + 100,
+         Variables_Defined    =>    5 + 26 + 100,
          Variables_Found      =>  100 +  4 +   9 + 2118 + 1950 + 1736,
          Variables_Undefined  =>    0 +  4 +   9 +    0 +    0 +    0,
          Variables_Replaced   =>  100 +  0 +   0 + 2118 + 1950 + 1736,
@@ -128,7 +127,7 @@ package body Directory_Tests is
       Settings.Replacement_In_File_Names   := False;
       Settings.Delete_Source_Files         := True;
       Settings.Overwrite_Destination_Files := True;
-      Settings.Undefined_Variable_Action   := Empty;
+      Settings.Undefined_Action            := Empty;
       Settings.Abort_On_Error              := True;
 
       Dir.Copy_File
@@ -177,9 +176,8 @@ package body Directory_Tests is
       Settings.Delete_Source_Files         := True;  --  changed in def file
       Settings.Overwrite_Destination_Files := True;
       Settings.Enable_Defined_Settings     := True;
-      Settings.Undefined_Variable_Action   := Empty; --  changed in def file
-      Settings.Undefined_Variable_Alert    := None;  --  changed in def file
-      Settings.Undefined_Filter_Alert      := None;  --  changed in def file
+      Settings.Undefined_Action            := Empty; --  changed in def file
+      Settings.Undefined_Alert             := None;  --  changed in def file
       Settings.Abort_On_Error              := True;  --  changed in def file
       --!pp off
       Errors := Apply (
@@ -208,7 +206,7 @@ package body Directory_Tests is
          Files_Processed      =>   7,
          Files_Renamed        =>   2,
          Files_Overwritten    =>   0,
-         Variables_Defined    =>   6 + 26 + 100,
+         Variables_Defined    =>   5 + 26 + 100,
          Variables_Found      => 100 +  4 +   9 + 2118 + 1950 + 1736,
          Variables_Undefined  =>   0 +  4 +   9 +    0 +    0 +    0,
          Variables_Replaced   => 100 +  0 +   0 + 2118 + 1950 + 1736,

--- a/tests/src/errors_tests.adb
+++ b/tests/src/errors_tests.adb
@@ -54,7 +54,7 @@ package body Errors_Tests is
       --  ----- undefined variable --------------------------------------------
       Settings.Abort_On_Error              := True;
       Settings.Overwrite_Destination_Files := True;
-      Settings.Undefined_Variable_Alert    := Error;
+      Settings.Undefined_Alert             := Error;
       Results                              := [others => 0];
       --!pp off
       Errors := Apply (

--- a/tests/src/filters_tests.adb
+++ b/tests/src/filters_tests.adb
@@ -178,7 +178,7 @@ package body Filters_Tests is
 
       Check_MD5_Digest
         ("suite/tmp/invalid-filters.txt", "835fc3f56a9e2060cdb1d4ac0a75c401",
-         "835fc3f56a9e2060cdb1d4ac0a75c401");
+         "4648a17d49139ef4ea9249711c8455a6");
 
       --  ----- variable substitution with text filters: empty and warn -------
       Settings.Overwrite_Destination_Files := True;
@@ -210,7 +210,7 @@ package body Filters_Tests is
 
       Check_MD5_Digest
         ("suite/tmp/invalid-filters.txt", "cc2e6aa0f37953e2f79eeb635da74c39",
-         "cc2e6aa0f37953e2f79eeb635da74c39");
+         "d6b7e1fbd7fa6eba943b417e55f56271");
 
       --  ----- undefined custom text filter: ignore and warn -----------------
       Settings.Overwrite_Destination_Files := True;
@@ -243,7 +243,7 @@ package body Filters_Tests is
 
       Check_MD5_Digest
         ("suite/tmp/custom-filters.txt", "b7501d2677f79ecd9f5969dee6574bf3",
-         "b7501d2677f79ecd9f5969dee6574bf3");
+         "a8ab488e7078d006c15347c2c17143c0");
 
       --  ----- undefined custom text filter: empty and error -----------------
       Settings.Overwrite_Destination_Files := True;
@@ -277,7 +277,7 @@ package body Filters_Tests is
 
       Check_MD5_Digest
         ("suite/tmp/custom-filters.txt", "6e727f4e4fb46327223feae96e6f74ca",
-         "6e727f4e4fb46327223feae96e6f74ca");
+         "72a028acdb8b8f85f64de1c5ce776a0d");
    end Test_Invalid_Filters;
 
    ----------------------

--- a/tests/src/support.ads
+++ b/tests/src/support.ads
@@ -21,9 +21,8 @@ package Support is
       Delete_Source_Files          => False,   --  Do not remove source files
       Overwrite_Destination_Files  => True,    --  Overwrite destination files
       Enable_Defined_Settings      => True,
-      Undefined_Variable_Action    => Mold.Ignore,
-      Undefined_Variable_Alert     => Mold.Warning,
-      Undefined_Filter_Alert       => Mold.Warning,
+      Undefined_Action             => Mold.Ignore,
+      Undefined_Alert              => Mold.Warning,
       Abort_On_Error               => True
    );
    --!pp on

--- a/tests/src/variables_tests.adb
+++ b/tests/src/variables_tests.adb
@@ -312,8 +312,8 @@ package body Variables_Tests is
          "0faaaac0483521b52b19b0832c45855c");
 
       --  ----- undefined variables ignored and no warning --------------------
-      Settings.Undefined_Variable_Action := Mold.Ignore;
-      Settings.Undefined_Variable_Alert  := Mold.None;
+      Settings.Undefined_Action := Mold.Ignore;
+      Settings.Undefined_Alert  := Mold.None;
       --!pp off
       Errors := Apply (
          Source     => "suite/mold/lorem-ipsum.txt.mold",
@@ -342,8 +342,8 @@ package body Variables_Tests is
          "0b57373fbc9240bf183adfd5eb3fd82b");
 
       --  ----- undefined variables ignored, warning issued -------------------
-      Settings.Undefined_Variable_Action := Mold.Ignore;
-      Settings.Undefined_Variable_Alert  := Mold.Warning;
+      Settings.Undefined_Action := Mold.Ignore;
+      Settings.Undefined_Alert  := Mold.Warning;
       --!pp off
       Errors := Apply (
          Source     => "suite/mold/lorem-ipsum.txt.mold",
@@ -373,8 +373,8 @@ package body Variables_Tests is
          "0b57373fbc9240bf183adfd5eb3fd82b");
 
       --  ----- undefined variables emptied and no warning --------------------
-      Settings.Undefined_Variable_Action := Mold.Empty;
-      Settings.Undefined_Variable_Alert  := Mold.None;
+      Settings.Undefined_Action := Mold.Empty;
+      Settings.Undefined_Alert  := Mold.None;
       --!pp off
       Errors := Apply (
          Source     => "suite/mold/lorem-ipsum.txt.mold",
@@ -403,8 +403,8 @@ package body Variables_Tests is
          "171564ce81dfde5ca643e2227e8524b7");
 
       --  ----- undefined variables emptied, warning issued -------------------
-      Settings.Undefined_Variable_Action := Mold.Empty;
-      Settings.Undefined_Variable_Alert  := Mold.Warning;
+      Settings.Undefined_Action := Mold.Empty;
+      Settings.Undefined_Alert  := Mold.Warning;
       --!pp off
       Errors := Apply (
          Source     => "suite/mold/lorem-ipsum.txt.mold",
@@ -434,8 +434,8 @@ package body Variables_Tests is
          "171564ce81dfde5ca643e2227e8524b7");
 
       --  ----- undefined mandatory variable, no abort on error ---------------
-      Settings.Undefined_Variable_Action := Mold.Ignore;
-      Settings.Undefined_Variable_Alert  := Mold.Warning;
+      Settings.Undefined_Action := Mold.Ignore;
+      Settings.Undefined_Alert  := Mold.Warning;
       Settings.Abort_On_Error            := False;
       --!pp off
       Errors := Apply (

--- a/tests/suite/dir/mold.toml
+++ b/tests/suite/dir/mold.toml
@@ -1,8 +1,7 @@
 mold-replacement-in-file-names = "true"
 mold-delete-source-files = "false"
-mold-undefined-variable-action = "ignore"
-mold-undefined-variable-alert = "warning"
-mold-undefined-filter-alert = "warning"
+mold-undefined-action = "ignore"
+mold-undefined-alert = "warning"
 mold-abort-on-error = "true"
 
 a = "arcu"          #    91  {{a}}

--- a/tests/suite/mold/custom-filters.txt.mold
+++ b/tests/suite/mold/custom-filters.txt.mold
@@ -6,11 +6,11 @@ Replace all chars by '-' : {{Title/s-}}          1
 Replace all chars by '=' : {{Title/s=}}          1
 Replace all chars    '/' : {{Title/s//}}         1
 Replace all chars by '/' : {{Title/0}}           1
-Same as before:          : {{Title/0}}           1
-Possibly undefined:      : {{Title/2}}           1
+Same as before?:         : {{Title/1}}           1
+Possibly undefined:      : {{Title/9}}           1
 
 Line        : [{{ Line  }}]
 Line/Tl     : [{{ Line/Tl/0}}]                   2
 Line/Tl     : [{{ Line/0/Tl}}]                   2
-Line/Tr     : [{{ Line/Tr/0}}]                   2
-Line/Tr     : [{{ Line/0/Tr}}]                   2
+Line/Tr     : [{{ Line/Tr/8}}]                   2
+Line/Tr     : [{{ Line/8/Tr}}]                   2

--- a/tests/suite/mold/invalid-filters.txt.mold
+++ b/tests/suite/mold/invalid-filters.txt.mold
@@ -2,36 +2,38 @@
                                  Number of filters
                            -----------------------
 Space Trimming: T{l,r,b,s,a}
-No parameter             : {{Title/T}}           1
-Invalid parameter        : {{Title/Tz}}          1
+No parameter             : {{Title/T}}
+Invalid parameter        : {{Title/Tz}}
 
 Replace: r{a,f,l}<SRC><DST>
-No parameters            : {{Title/r}}           1
-One wrong parameter      : {{Title/rz}}          1
-Two wrong parameters     : {{Title/rzs}}         1
-Three wrong parameters   : {{Title/rzsq}}        1
+No parameters            : {{Title/r}}
+One wrong parameter      : {{Title/rz}}
+Two wrong parameters     : {{Title/rzs}}
+Three wrong parameters   : {{Title/rzsq}}
 
 Sequence: s<CHAR>
-No parameters            : {{Title/s}}           1
+No parameters            : {{Title/s}}
 
 Delete: D<CHAR>
-No parameters            : {{Title/D}}           1
+No parameters            : {{Title/D}}
 
 Padding: p{l,r}<CHAR><NUM>
-No parameters            : {{Title/p}}           1
-Wrong direction          : {{Title/pq}}          1
-Only two parameters      : {{Title/plw}}         1
-Wrong direction          : {{Title/pzw3}}        1
-Wrong number             : {{Title/plww}}        1
+No parameters            : {{Title/p}}
+Wrong direction          : {{Title/pq}}
+Only two parameters      : {{Title/plw}}
+Wrong direction          : {{Title/pzw3}}
+Wrong number             : {{Title/plww}}
 
 Truncate: W<NUM>
-No parameters            : {{Title/W}}           1
-Wrong width              : {{Title/Ww}}          1
+No parameters            : {{Title/W}}
+Wrong width              : {{Title/Ww}}
 
 Case: c{l,c,u}
-No parameters            : {{Title/c}}           1
-Wrong case               : {{Title/cz}}          1
+No parameters            : {{Title/c}}
+Wrong case               : {{Title/cz}}
 
 Naming Style: n{f,c,C,U,s,S,i,A,d,t,T}
-No parameters            : {{Title/n}}           1
-Wrong naming style       : {{Title/nn}}          1
+No parameters            : {{Title/n}}
+Wrong naming style       : {{Title/nn}}
+
+Undefined filter         : {{Title/Z}}

--- a/tests/suite/mold/predefined-filters.txt.mold
+++ b/tests/suite/mold/predefined-filters.txt.mold
@@ -19,7 +19,7 @@ Replace first i with @   : {{Title/rfi@}}        1
 Replace last i with @    : {{Title/rli@}}        1
 Replace all chars    '/' : {{Title/s//}}         1     57
 Random Transforms        : {{Title/rai1/rlt*/rae3/rat_/ra_^/raa4/ras5/rao0/raf7}} 9, 66
-Non-existent filter      : {{Title/Q}}           1
+Pad to 20 right          : {{Title/pr*20}}           1
 Pad to 40 right          : {{Title/pr*40}}       1
 Pad to 40 left           : {{Title/pl*40}}       1
 Truncate to 10           : 1234567890

--- a/tests/suite/toml/invalid-setting-05.toml
+++ b/tests/suite/toml/invalid-setting-05.toml
@@ -1,1 +1,1 @@
-mold-undefined-variable-action = "nothing"
+mold-undefined-action = "nothing"

--- a/tests/suite/toml/invalid-setting-06.toml
+++ b/tests/suite/toml/invalid-setting-06.toml
@@ -1,1 +1,1 @@
-mold-undefined-variable-alert = "no alert at all"
+mold-undefined-alert = "no alert at all"


### PR DESCRIPTION
  * Modified the setting type to unify undefined actions and alerts for
      variables and text filters
  * `mold-undefined-variable-action` changed to `mold-undefined-action`:
    applies to variables and text filters
  * `mold-undefined-variable-alert` changed to `mold-undefined-alert`: applies
    to variables and text filters
  * Removed defined setting `mold-undefined-filter-alter`
  * Removed summary reported by text filter application
